### PR TITLE
Fix baseContract error on new contracts

### DIFF
--- a/scripts/fio_launch.sh
+++ b/scripts/fio_launch.sh
@@ -202,13 +202,6 @@ if [ $mChoice == 1 ]; then
                 echo 'No wasm file found at $PWD/build/contracts/eosio.wrap'
     fi
 
-    if [ -f bin/baseContract/master/fio.contracts/build/contracts/fio.staking/fio.staking.wasm ]; then
-            fio_staking_base_path="$basepath/fio.contracts/build/contracts/fio.staking"
-            else
-                echo 'No wasm file found at $PWD/build/contracts/fio.staking'
-    fi
-
-
     export eosio_bios_contract_name_path
     export fio_system_contract_name_path
     export eosio_msig_contract_name_path

--- a/scripts/fio_launch.sh
+++ b/scripts/fio_launch.sh
@@ -42,14 +42,12 @@ fi
 if [ $mChoice == 2 ]; then
     echo Updating Current Base Contracts
     cd ../fio.devtools/bin/baseContract/master/
-    git clone http://github.com/fioprotocol/fio.contracts
+    git clone http://github.com/fioprotocol/fio.contracts -b release/2.5.x
     cd fio.contracts/
     ./build.sh
     cp ./contracts/fio.fee/fio.fee.abi ./build/contracts/fio.fee/fio.fee.abi
     cp ./contracts/fio.address/fio.address.abi ./build/contracts/fio.address/fio.address.abi
     cp ./contracts/fio.request.obt/fio.request.obt.abi ./build/contracts/fio.request.obt/fio.request.obt.abi
-    # cp ./contracts/fio.staking/fio.staking.abi ./build/contracts/fio.staking/fio.staking.abi
-#    cp ./contracts/fio.escrow/fio.escrow.abi ./build/contracts/fio.escrow/fio.escrow.abi
 
     echo Building Development Contracts
     cd ../../../../../fio.contracts

--- a/scripts/launch/05_bind_contracts.sh
+++ b/scripts/launch/05_bind_contracts.sh
@@ -15,6 +15,3 @@ sleep 1.5s
 ./clio -u http://localhost:8889 set contract fio.treasury $fio_treasury_base_path fio.treasury.wasm fio.treasury.abi --permission fio.treasury@active
 sleep 1.5s
 ./clio -u http://localhost:8889 set contract eosio.wrap $eosio_wrap_base_path eosio.wrap.wasm eosio.wrap.abi --permission eosio.wrap@active
-sleep 1.5s
-./clio -u http://localhost:8889 set contract -j eosio.staking $fio_staking_base_path eosio.staking.wasm eosio.staking.abi --permission eosio.staking@active
-sleep 1.5s


### PR DESCRIPTION
This PR fixes the base contracts to launch v2.5.x branches so no changes are necessary to core the fio core. 